### PR TITLE
feat: unified JSONL event log, docs qualification, tests, setup improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,28 +8,21 @@
 2. Apply hooks from `hooks/` for deterministic enforcement
 3. Use templates from `templates/` for new projects
 
-## Module Index
+## Modules (Consolidated v4.0)
 
-| # | Module | Use When |
-|---|--------|----------|
-| 00 | [Fundamentals](modules/00-fundamentals.md) | Context engineering, token budget |
-| 01 | [File Architecture](modules/01-file-architecture.md) | Tool hierarchy, CLAUDE.md structure |
-| 02 | [Session Management](modules/02-session-management.md) | Compaction, subagents, /clear |
-| 03 | [Persistence](modules/03-persistence.md) | Memory system, [USER]/[AUTO] tags |
-| 04 | [Enforcement](modules/04-enforcement.md) | Hooks, frozen files, compliance |
-| 05 | [CS Algorithms](modules/05-cs-algorithms.md) | Circuit Breaker, WAL, ARC |
-| 06 | [Operational Patterns](modules/06-operational-patterns.md) | Anti-loop, REHYDRATE, checklists |
-| 07 | [Smart Context](modules/07-smart-context.md) | Semantic routing (optional) |
-| 08 | [Advanced](modules/08-advanced.md) | Vector DB, agent teams (experimental) |
-| 09 | [Memory Compiler](modules/09-memory-compiler.md) | GC, scoring, context-index |
-| 10 | [Context OS](modules/10-context-os.md) | 5-tier architecture, budget management |
-| 11 | [Prompt Caching](modules/11-prompt-caching.md) | Stable prefix, cached token metrics |
+| Module | Topic | Use When |
+|--------|-------|----------|
+| [01-core](modules/01-core.md) | CORE | Fundamentals, architecture, persistence, enforcement, memory, GPS |
+| [02-operations](modules/02-operations.md) | OPERATIONS | Sessions, patterns, prompt caching |
+| [03-advanced](modules/03-advanced.md) | ADVANCED | CS algorithms, smart context, RAG, agent orchestration |
 
 ## Core Principle
 
 ```
 CLAUDE.md = guidance (advisory — 6% compliance in production)
-Hooks with exit 2 = enforcement (deterministic — cannot be bypassed)
+Hooks with exit 2 = enforcement
+  Edit/Write: deterministic (exact path match, cannot be bypassed)
+  Bash:       best-effort (pattern matching, covers common cases)
 Critical rules → hooks.  Style/preferences → CLAUDE.md.
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ AI agents follow CLAUDE.md rules only **6% of the time** in production (Nuconic:
 
 ```
 CLAUDE.md = guidance (advisory, model may ignore)
-Hooks + exit 2 = deterministic block for matched tool events/patterns
+Hooks + exit 2 = enforcement for matched tool events/patterns
+  Edit/Write tools:  deterministic (exact path match, cannot be bypassed)
+  Bash tool:         best-effort (pattern matching, covers common cases)
 ```
 
 ## Quick Start
@@ -69,12 +71,14 @@ bash evals/run.sh --enforce-gates
 | [wal-logger.sh](hooks/wal-logger.sh) | PreToolUse | Log intent before destructive actions |
 | [backup-enforcement.sh](hooks/backup-enforcement.sh) | PreToolUse | Require validated backup manifest before deploy/migrate |
 | [sync-gps.sh](hooks/sync-gps.sh) | Stop | Update Global Project State (v4.0) |
+| [hook-event.sh](hooks/hook-event.sh) | Library | Shared JSONL event logging for all hooks |
 
 ## Tooling
 
 | Tool | Purpose | Usage |
 |------|---------|-------|
 | [setup.sh](setup.sh) | Interactive or deterministic project setup | `bash setup.sh /path/to/project --non-interactive --secure-defaults` |
+| [stats.sh](stats.sh) | Observability dashboard (metrics, CB state, GPS, events) | `bash stats.sh /path/to/project` |
 | [doctor.sh](doctor.sh) | Health check & diagnostics (`--strict` for CI) | `bash doctor.sh --strict /path/to/project` |
 | [tests/test-hooks.sh](tests/test-hooks.sh) | Automated hook tests (100+ tests) | `bash tests/test-hooks.sh` |
 | [evals/run.sh](evals/run.sh) | Reproducible benchmark report (+ optional quality gates) | `bash evals/run.sh --enforce-gates` |

--- a/hooks/circuit-breaker-gate.sh
+++ b/hooks/circuit-breaker-gate.sh
@@ -39,6 +39,11 @@ PROJECT_HASH=$(project_hash "$PROJECT_DIR")
 # Project-scoped breaker state prevents cross-repo strict-gate blocking.
 STATE_DIR="$BASE_STATE_DIR/$PROJECT_HASH"
 
+# Unified JSONL event logging
+_BESTAI_TOOL_NAME="Bash"
+# shellcheck source=hook-event.sh
+source "$(dirname "$0")/hook-event.sh" 2>/dev/null || true
+
 [ -d "$STATE_DIR" ] || exit 0
 
 BLOCKED=0
@@ -72,6 +77,7 @@ for state_file in "$STATE_DIR"/*; do
 done
 
 if [ "$BLOCKED" -eq 1 ]; then
+    emit_event "circuit-breaker-gate" "BLOCK" "{\"pattern\":\"$BLOCK_FILE\",\"remaining_s\":$MIN_REMAINING}" 2>/dev/null || true
     if [ "$BESTAI_DRY_RUN" = "1" ]; then
         echo "[DRY-RUN] WOULD BLOCK: Circuit Breaker OPEN. Pattern: $BLOCK_FILE. Retry in ${MIN_REMAINING}s." >&2
         exit 0

--- a/hooks/hook-event.sh
+++ b/hooks/hook-event.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# hooks/hook-event.sh — Shared JSONL event logging for all hooks
+# Source this file from any hook: source "$(dirname "$0")/hook-event.sh"
+#
+# Usage:
+#   emit_event "check-frozen" "BLOCK" '{"file":"auth.ts","mode":"direct"}'
+#   emit_event "circuit-breaker" "OPEN" '{"sig":"grep_fail","count":3}'
+#   emit_event "backup-enforcement" "ALLOW" '{}'
+#
+# Output: one JSON line per event to $BESTAI_EVENT_LOG
+# Format: {"ts":"ISO","hook":"name","action":"BLOCK|ALLOW|OPEN|...","tool":"Bash|Edit|Write","project":"hash","detail":{...}}
+#
+# Env vars:
+#   BESTAI_EVENT_LOG — override log path (default: ~/.cache/bestai/events.jsonl)
+#   BESTAI_EVENT_LOG_DISABLED=1 — disable event logging entirely
+
+# Guard against double-sourcing
+[ "${_BESTAI_HOOK_EVENT_LOADED:-0}" = "1" ] && return 0
+_BESTAI_HOOK_EVENT_LOADED=1
+
+_bestai_project_hash() {
+    local src="${CLAUDE_PROJECT_DIR:-.}"
+    if command -v md5sum >/dev/null 2>&1; then
+        echo "$src" | md5sum | awk '{print substr($1,1,16)}'
+    elif command -v shasum >/dev/null 2>&1; then
+        echo "$src" | shasum -a 256 | awk '{print substr($1,1,16)}'
+    else
+        echo "$src" | cksum | awk '{print $1}'
+    fi
+}
+
+_BESTAI_PROJECT_HASH=$(_bestai_project_hash)
+
+if [ -z "${BESTAI_EVENT_LOG:-}" ]; then
+    _BESTAI_EVENT_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/bestai"
+    BESTAI_EVENT_LOG="$_BESTAI_EVENT_DIR/events.jsonl"
+else
+    _BESTAI_EVENT_DIR="${BESTAI_EVENT_LOG%/*}"
+fi
+
+# Resolve the tool name from hook input if available.
+# Callers may set _BESTAI_TOOL_NAME before sourcing or calling emit_event.
+_bestai_resolve_tool() {
+    echo "${_BESTAI_TOOL_NAME:-unknown}"
+}
+
+# emit_event HOOK_NAME ACTION [DETAIL_JSON]
+#   HOOK_NAME: e.g. "check-frozen", "circuit-breaker", "backup-enforcement"
+#   ACTION: e.g. "BLOCK", "ALLOW", "OPEN", "CLOSED", "HALF_OPEN", "ERROR"
+#   DETAIL_JSON: optional JSON object string (default: "{}")
+emit_event() {
+    [ "${BESTAI_EVENT_LOG_DISABLED:-0}" = "1" ] && return 0
+
+    local hook="${1:?emit_event requires hook name}"
+    local action="${2:?emit_event requires action}"
+    local detail="${3:-{\}}"
+    local ts tool
+
+    ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    tool=$(_bestai_resolve_tool)
+
+    mkdir -p "$_BESTAI_EVENT_DIR" 2>/dev/null || return 0
+
+    if command -v jq >/dev/null 2>&1; then
+        # Build proper JSON via jq for correctness
+        jq -cn \
+            --arg ts "$ts" \
+            --arg hook "$hook" \
+            --arg action "$action" \
+            --arg tool "$tool" \
+            --arg project "$_BESTAI_PROJECT_HASH" \
+            --argjson detail "$detail" \
+            '{ts:$ts,hook:$hook,action:$action,tool:$tool,project:$project,detail:$detail}' \
+            >> "$BESTAI_EVENT_LOG" 2>/dev/null || true
+    else
+        # Fallback: manual JSON (no jq). detail must be valid JSON already.
+        printf '{"ts":"%s","hook":"%s","action":"%s","tool":"%s","project":"%s","detail":%s}\n' \
+            "$ts" "$hook" "$action" "$tool" "$_BESTAI_PROJECT_HASH" "$detail" \
+            >> "$BESTAI_EVENT_LOG" 2>/dev/null || true
+    fi
+}
+
+# Convenience: rotate event log when it exceeds MAX_EVENTS lines.
+# Call from Stop hooks or periodically.
+rotate_event_log() {
+    local max_events="${1:-5000}"
+    [ ! -f "$BESTAI_EVENT_LOG" ] && return 0
+
+    local count
+    count=$(wc -l < "$BESTAI_EVENT_LOG" 2>/dev/null | tr -d ' ')
+    [ "$count" -le "$max_events" ] && return 0
+
+    local keep=$((max_events * 4 / 5))  # keep 80%
+    local archive="${BESTAI_EVENT_LOG%.jsonl}-archive.jsonl"
+    local tmp
+    tmp=$(mktemp)
+
+    head -n "$((count - keep))" "$BESTAI_EVENT_LOG" >> "$archive"
+    tail -n "$keep" "$BESTAI_EVENT_LOG" > "$tmp"
+    mv "$tmp" "$BESTAI_EVENT_LOG"
+}


### PR DESCRIPTION
## Summary

- **Unified JSONL event log (#48)**: New `hooks/hook-event.sh` shared library replaces ad-hoc `hook-metrics.log`. All enforcement hooks (check-frozen, circuit-breaker, circuit-breaker-gate, backup-enforcement) now emit structured JSONL events with `emit_event()`. Includes rotation support.
- **Docs qualification (#22)**: README and CLAUDE.md now honestly distinguish Edit/Write (deterministic enforcement) from Bash (best-effort pattern matching).
- **Test coverage (#44)**: Added 8 event logging tests (emit, disabled, valid JSON, integration, rotation). Total: 134 tests, all passing.
- **Setup improvements (#39)**: Added `--force-update-hooks` flag for updating existing hooks. `hook-event.sh` auto-installed alongside hooks. CLAUDE.md module index updated to v4.0 consolidated structure.
- **Stats dashboard**: New Event Log section in stats.sh shows per-project events, blocks, and hook distribution.

## Test plan

- [x] All 134 hook tests passing (`bash tests/test-hooks.sh`)
- [x] hook-event.sh works under `set -euo pipefail` (nounset bug fixed)
- [x] JSONL output validated with jq
- [x] Event log rotation tested
- [x] Disabled mode produces no file
- [x] check-frozen BLOCK and ALLOW events verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)