### PR TITLE
fix: remove global bestai dependency from plan command

### DIFF
--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -1609,6 +1609,11 @@ CODE=$?
 assert_exit "bestai shared-context-merge --help -> exit 0" "0" "$CODE"
 assert_contains "bestai shared-context-merge --help contains Usage" "$OUTPUT" "Usage:"
 
+OUTPUT=$(node "$REPO_ROOT/bin/bestai.js" plan --help 2>&1)
+CODE=$?
+assert_exit "bestai plan --help -> exit 0" "0" "$CODE"
+assert_contains "bestai plan --help contains Usage" "$OUTPUT" "Usage:"
+
 OUTPUT=$(node - "$REPO_ROOT" <<'NODE'
 const fs = require('fs');
 const path = require('path');

--- a/tools/plan.sh
+++ b/tools/plan.sh
@@ -4,9 +4,26 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+usage() {
+    cat <<'EOF'
+Usage: bestai plan "<task description>"
+
+Examples:
+  bestai plan "Analyze the auth system"
+  bestai plan "Prepare migration strategy for PostgreSQL 17"
+EOF
+}
+
+if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+    usage
+    exit 0
+fi
+
 TASK="${1:-}"
 if [ -z "$TASK" ]; then
-    echo "Usage: bestai plan 'description'"
+    usage >&2
     exit 1
 fi
 
@@ -15,7 +32,10 @@ echo -e "\033[2m[SAFE] Code writing tools are temporarily restricted.\033[0m"
 
 # We use the swarm dispatcher but force a specialized "Planning" prompt
 # and a lower depth to save tokens.
-bestai swarm --vendor gemini --task "ARCHITECT MODE: Create a detailed PROPOSAL.md for: $TASK. DO NOT edit or write code. Analyze only." --depth fast
+bash "$SCRIPT_DIR/swarm-dispatch.sh" \
+    --vendor gemini \
+    --task "ARCHITECT MODE: Create a detailed PROPOSAL.md for: $TASK. DO NOT edit or write code. Analyze only." \
+    --depth fast
 
 echo -e "\n\033[1;32m✅ Proposal generated.\033[0m"
 echo "Review PROPOSAL.md then use 'bestai permit' to allow implementation."


### PR DESCRIPTION
## Summary
- remove implicit global `bestai` dependency in `tools/plan.sh`
- call local `tools/swarm-dispatch.sh` by path
- add explicit `--help` contract for `bestai plan`
- add regression test coverage in `tests/test-hooks.sh`

## Validation
- `node bin/bestai.js plan --help` -> exit 0 + Usage
- `npm test` -> pass (176/176 + tools suite)
