### PR TITLE
fix: coerce isRawModeSupported to boolean for Ink strict check

### DIFF
--- a/orchestrator/src/tui/App.tsx
+++ b/orchestrator/src/tui/App.tsx
@@ -116,7 +116,7 @@ const App: React.FC<Props> = ({ dbPath }) => {
       scroll(1);
       return;
     }
-  }, { isActive: !inputMode && isRawModeSupported });
+  }, { isActive: !inputMode && !!isRawModeSupported });
 
   return (
     <Box flexDirection="column" width="100%">

--- a/orchestrator/src/tui/components/ConversationPanel.tsx
+++ b/orchestrator/src/tui/components/ConversationPanel.tsx
@@ -107,7 +107,7 @@ const ConversationPanel: React.FC<Props> = ({
       setBuffer((b) => b.slice(0, cursor) + input + b.slice(cursor));
       setCursor((c) => c + input.length);
     }
-  }, { isActive: inputMode && focused && isRawModeSupported !== false });
+  }, { isActive: inputMode && focused && !!isRawModeSupported });
 
   // Compute visible messages
   const startIdx = Math.max(0, notifications.length - VISIBLE_ROWS - scrollOffset);


### PR DESCRIPTION
## Summary
- Follow-up to PR #143 — `isRawModeSupported` can be `undefined` (not `false`) when no TTY
- Ink 3.2.0 checks `options.isActive === false` (strict equality), so `undefined` bypasses the guard and crashes with `setRawMode`
- Fix: `!!isRawModeSupported` coerces to strict boolean in both `useInput` call sites

## Test plan
- [x] `npm run build` — 0 errors
- [x] `echo "" | node dist/tui/cli.js` — renders TUI with "read-only mode (no TTY)", no crash
- [ ] From real terminal — full interactive mode unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)